### PR TITLE
#23 init drush

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ The skeleton requires at least bash to run.
 ## Commands
 The drupal-skeleton contains a set of bash scripts (commands):
 
+- [`bin/init`][link-command-init] : Setup or update the skeleton environment.
 - [`bin/install`][link-command-install] : Download core and required contributed
   modules, themes and libraries and install the project.
 - [`bin/reset`][link-command-reset] : Reset an installed project back to its
   freshly installed state.
 - [`bin/upgrade`][link-command-upgrade]: Upgrade an installed project.
-- [`bin/build`][link-command-build]: Create a package of the project.
-- [`bin/backup`][link-command-backup]: Create a backup of the installed project.
-- [`bin/restore`][link-command-restore]: Restore the project from one of the
+- [`bin/build`][link-command-build] : Create a package of the project.
+- [`bin/backup`][link-command-backup] : Create a backup of the installed project.
+- [`bin/restore`][link-command-restore] : Restore the project from one of the
   created backups.
 - [`bin/drush`][link-command-drush] : Run a drush command within the `web`
   directory.
@@ -57,6 +58,7 @@ The drupal-skeleton requires a minimal configuration to get started.
 [link-documentation]: bin/docs/README.md
 [link-config]: bin/docs/config.md
 [link-requirements]: bin/docs/requirements.md
+[link-command-init]: bin/docs/command-init.md
 [link-command-install]: bin/docs/command-install.md
 [link-command-reset]: bin/docs/command-reset.md
 [link-command-upgrade]: bin/docs/command-upgrade.md

--- a/bin/CHANGELOG.md
+++ b/bin/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Added
 - #19 : Added bin/drush command and its documentation.
 - #20 : Added bin/init command and its documentation.
+- #23 : Install composer locally by running the bin/init command.
+- #23 : Install drush locally by running the bin/init command.
 
 ### Fixed
 - Error when there is no hook info available for a specific command.

--- a/bin/docs/README.md
+++ b/bin/docs/README.md
@@ -2,12 +2,15 @@
 
 Overview of all Skeleton Documentation:
 
+
 ## Quick Start
 - [Quick start](quick-start.md) : Short guide to get you started within minutes.
+
 
 ## Requirements
 - [Requirements](requirements.md) : Minimal requirements to use the
   drupal-skeleton.
+
 
 ## Commands
 - [bin/init](command-init.md) : Setup the skeleton environment.
@@ -22,6 +25,11 @@ Overview of all Skeleton Documentation:
 - [bin/backup](command-backup.md) : Create a backup of the installed project.
 - [bin/restore](command-restore.md) : Restore one of the backups.
 - [bin/drush](command-drush.md) : Run a drush command within the `web`
+  directory.
+
+Commands installed during the init command:
+- [bin/composer](https://getcomposer.org/) : A local copy of composer.
+- [bin/...](config-bin.md) : Any custom command as defined in the `config/bin`
   directory.
 
 

--- a/bin/docs/command-init.md
+++ b/bin/docs/command-init.md
@@ -31,7 +31,19 @@ called using the following command:
 $ bin/composer
 ```
 
-#### 2. Add custom commands to the `bin` directory
+#### 2. Install drush
+[Drush][link-drush] is a command line interface to perform actions on drupal. It
+is used by the skeleton to install and interact with the drupal installation in
+the `web` directory.
+
+By default the [dev-master][link-drush-master] branch of drush will be used as
+the version to install locally. You can set a custom version by defining this in
+the [`$DRUSH_VERSION`][link-config-config-drush-version] variable in the config
+file. You can also use a globally installed drush version by setting the
+`$DRUSH_VERSION` variable to "global".
+
+
+#### 3. Add custom commands to the `bin` directory
 The skeleton allows to define custom commands in the `config/bin` directory.
 This step will create a symlink for each custom command to the `bin` directory.
 This so all commands are run from the same directory.
@@ -82,6 +94,12 @@ This hook is included and run before composer is installed or updated locally.
 #### config/init/init_composer_after(_\<env\>).sh
 This hook is included and run after composer is installed or updated locally.
 
+#### config/init/init_drush_before(_\<env\>).sh
+This hook is included and run before drush is installed or updated locally.
+
+#### config/init/init_drush_after(_\<env\>).sh
+This hook is included and run after drush is installed or updated locally.
+
 #### config/init/init_custom_commands_before(_\<env\>).sh
 This hook is included and run before the custom commands are added to the `bin`
 directory.
@@ -106,5 +124,8 @@ This hook is included and run when the script is finished.
 [link-hooks]: hooks.md
 [link-config-bin]: config-bin.sh
 [link-composer]: https://getcomposer.org
+[link-drush]: https://github.com/drush-ops/drush
+[link-drush-master]: https://github.com/drush-ops/drush/tree/master
+[link-config-config-drush-version]: config-config.md#drush-version
 
 [link-overview]: README.md

--- a/bin/docs/config-config.md
+++ b/bin/docs/config-config.md
@@ -65,7 +65,7 @@ install a local version. This is defined by the `$DRUSH_VERSION` variable.
 The options are:
 
 - **DRUSH_VERSION="global"** : Use the globally installed drush command.
-- **DRUSH_VERSION="<branch or tag name>"** : Download a local drush command, use
+- **DRUSH_VERSION="branch or tag name"** : Download a local drush command, use
   the branch or tag to determen what version to download.
 
 > Note : The default is to download a local drush using the

--- a/bin/docs/config-config.md
+++ b/bin/docs/config-config.md
@@ -58,6 +58,20 @@ credentials from the config file:
   site url (`$ACCOUNT_NAME@$SITE_URL`).
 
 
+#### Drush version
+The skeleton provides the option to use a globally installed drush command or to
+install a local version. This is defined by the `$DRUSH_VERSION` variable.
+
+The options are:
+
+- **DRUSH_VERSION="global"** : Use the globally installed drush command.
+- **DRUSH_VERSION="<branch or tag name>"** : Download a local drush command, use
+  the branch or tag to determen what version to download.
+
+> Note : The default is to download a local drush using the
+> [dev-master][link-drush-dev-master] branch.
+
+
 
 ## Example config file
 
@@ -81,6 +95,9 @@ DB_HOST="localhost"
 ACCOUNT_NAME="admin"
 ACCOUNT_PASS="drupal"
 ACCOUNT_MAIL="$ACCOUNT_NAME@$SITE_URL"
+
+# Drush version.
+DRUSH_VERSION="dev-master"
 ```
 
 
@@ -90,5 +107,6 @@ ACCOUNT_MAIL="$ACCOUNT_NAME@$SITE_URL"
 
 
 [link-hooks]: hooks.md
+[link-drush-dev-master]: https://github.com/drush-ops/drush/tree/master
 
 [link-overview]: README.md

--- a/bin/docs/hooks-helpers.md
+++ b/bin/docs/hooks-helpers.md
@@ -251,6 +251,24 @@ Example to clear the cache:
 drupal_drush cc
 ```
 
+> Note: this function is a wrapper around
+> [`drupal_drush_run`](#drupal_drush_run). It will always use the same global or
+> local drush as defined in the configuration.
+
+#### drupal_drush_run
+The skeleton provides the option to use a locally (default) or globally
+installed drush command. This function will check what to use based on the
+configuration variable [`$DRUSH_VERSION`][link-config-config-drush-version].
+If that variable is set to "global" then the globally installed drush will be
+used by the skeleton.
+
+The difference between this function and `drupal_drush` is that this command
+will not use by default `web` as the working directory.
+
+```bash
+drupal_drush_run cc drush
+```
+
 #### drupal_is_installed
 Check if Drupal is installed (= there is a working Drupal platform). The
 function will echo 1 when ok, 0 if not ok.
@@ -360,6 +378,7 @@ file_copy_subdirectories "/path/to/source_directory" "/path/to/target_directory"
 
 
 [link-hooks-variables]: hooks-variables.md
+[link-config-config-drush-version]: config-config.md#drush-version
 
 [link-overview]: README.md
 

--- a/bin/docs/quick-start.md
+++ b/bin/docs/quick-start.md
@@ -31,6 +31,23 @@ directory structure. Use the same vhost URL as defined in the config file.
 
 
 
+## Run the init command
+The skeleton has some 3th party dependencies that are not included in the `bin`
+directory. They need to be installed by running the `bin/init` command:
+
+```bash
+$ bin/init
+```
+
+This command will:
+- Download Composer and install it in the `bin` directory.
+- Use composer to download and install Drush (and its dependencies)locally in
+  the `bin/vendor` directory.
+- Create symlinks from within the `bin` directory to the optional custom
+  commands as defined in the `config/bin` directory.
+
+
+
 ## Run the install command
 Install the project by running the `bin/install` command:
 
@@ -51,7 +68,7 @@ $ bin/install
 
 The new site is ready to start developing.
 
-From now on the [other 5 commands][link-commands] can be used.
+From now on [all commands][link-commands] can be used.
 
 
 
@@ -62,6 +79,7 @@ Now that you have a running installation you can start extending the project:
 - [Enable extra modules after the installation process][link-config-modules].
 - [Add custom install profiles, modules, themes and libraries][link-project].
 - [Extend the commands by implementing their hooks][link-hooks].
+- [Add extra commands specific for the project][link-config-bin].
 
 
 
@@ -73,6 +91,7 @@ Now that you have a running installation you can start extending the project:
 [link-config-config]: config-config.md
 [link-documentation]: README.md
 [link-commands]: README.md#commands
+[link-config-bin]: config-bin.md
 [link-config-make]: config-make.sh
 [link-config-modules]: config-modules.md
 [link-project]: project.md

--- a/bin/docs/requirements.md
+++ b/bin/docs/requirements.md
@@ -5,11 +5,16 @@ Linux distributions and Mac OSX.
 On top of that it requires you to have a working Apache, Mysql & PHP
 environment, see [minimal requirements to run Drupal][link-drupal-requirements].
 
-You also need to have [drush][link-drush] installed. There is no support for
-[drupalconsole][link-drupalconsole] for Drupal 8 (yet).
+The skeleton will download a local copy of composer and use it to install the
+latest [drush][link-drush] version locally for the project. There is the option
+to use a globally installed drush.
+[See configuration options][link-config-config].
+
+There is no support for [drupalconsole][link-drupalconsole] for Drupal 8 (yet).
 
 
 
 [link-drupal-requirements]: https://www.drupal.org/requirements
 [link-drush]: https://github.com/drush-ops/drush
+[link-config-config]: config-config.md#drush-version
 [link-drupalconsole]: http://drupalconsole.com/

--- a/bin/init
+++ b/bin/init
@@ -51,6 +51,7 @@ source "$DIR_SRC/init_custom_commands.sh"
 
 script_before_run
 init_composer_run
+init_drush_run
 init_custom_commands_run
 script_after_run
 

--- a/bin/init
+++ b/bin/init
@@ -21,6 +21,8 @@ echo
 markup_h1_divider
 markup_h1 " ${LWHITE}Initiate/update${LBLUE} environment for website ${WHITE}$SITE_NAME${LBLUE} ($ENVIRONMENT)"
 markup_h1_divider
+markup_h1_li "Composer will be installed or updated in the bin/ directory."
+markup_h1_li "Drush will be installed (or global installed drush will be used)."
 markup_h1_li "Any custom command will be included in the bin/ directory."
 markup_h1_divider
 echo

--- a/bin/init
+++ b/bin/init
@@ -43,6 +43,7 @@ fi
 # Includes.
 source "$DIR_SRC/script.sh"
 source "$DIR_SRC/init_composer.sh"
+source "$DIR_SRC/init_drush.sh"
 source "$DIR_SRC/init_custom_commands.sh"
 
 

--- a/bin/src/bootstrap.sh
+++ b/bin/src/bootstrap.sh
@@ -46,6 +46,7 @@ source "$DIR_SRC/include/options.sh"
 source "$DIR_SRC/include/colors.sh"
 source "$DIR_SRC/include/markup.sh"
 source "$DIR_SRC/include/message.sh"
+source "$DIR_SRC/include/composer.sh"
 source "$DIR_SRC/include/drupal.sh"
 
 # Load the config file.

--- a/bin/src/drupal_make.sh
+++ b/bin/src/drupal_make.sh
@@ -34,7 +34,7 @@ function drupal_make_run {
   # Make Drupal core.
   markup_h1 "Download Drupal core"
   markup_h2 "_core.make"
-  drush make "$DIR_CONFIG/make/_core.make" "$DIR_WEB"
+  drupal_drush_run make "$DIR_CONFIG/make/_core.make" "$DIR_WEB"
   echo
 
   # 1. Default make files.
@@ -82,7 +82,7 @@ function drupal_make_run_file {
   # Run all make files in the configuration.
   for make_file in ${MAKE_FILES[@]}; do
     markup_h2 "${make_file}"
-    drush make --no-core "$DIR_CONFIG/make/${make_file}" "$DIR_WEB"
+    drupal_drush_run make --no-core "$DIR_CONFIG/make/${make_file}" "$DIR_WEB"
   done
   echo
 }

--- a/bin/src/help/init_description.txt
+++ b/bin/src/help/init_description.txt
@@ -1,6 +1,7 @@
 The init script will initiate or update the project environment.
 The script will:
   * Install or update composer locally.
+  * Install or update drush locally (if not configured to use global drush).
   * Symlink any custom command from within the config/bin to the bin directory.
     This allows you to add custom commands to the project.
 

--- a/bin/src/hook_info/hook/init_drush.sh
+++ b/bin/src/hook_info/hook/init_drush.sh
@@ -1,0 +1,4 @@
+markup_h2 "Install or update local drush"
+markup "${GREY}config/${SCRIPT_NAME}/${RESTORE}init_drush_before${GREY}(_${ENVIRONMENT})${RESTORE}.sh
+${GREY}config/${SCRIPT_NAME}/${RESTORE}init_drush_after${GREY}(_${ENVIRONMENT})${RESTORE}.sh
+"

--- a/bin/src/hook_info/init.sh
+++ b/bin/src/hook_info/init.sh
@@ -8,5 +8,6 @@ hook_info_run_load "common.sh"
 # Script specific information.
 hook_info_run_load "script_before.sh"
 hook_info_run_load "init_composer.sh"
+hook_info_run_load "init_drush.sh"
 hook_info_run_load "init_custom_commands.sh"
 hook_info_run_load "script_after.sh"

--- a/bin/src/include/composer.sh
+++ b/bin/src/include/composer.sh
@@ -1,0 +1,22 @@
+################################################################################
+# Include script that holds helper functions about Composer.
+################################################################################
+
+##
+# Run a composer command.
+#
+# This will run the bin/composer command with surpression of the XDEBUG warning.
+##
+function composer_run {
+  COMPOSER_DISABLE_XDEBUG_WARN=1 "$DIR_BIN/composer" "$@"
+}
+
+##
+# Run a composer command within the skeleton context.
+#
+# Use this to perform composer commands on the set of packages required and
+# installed by the skeleton.
+##
+function composer_skeleton_run {
+  composer_run "$@" --working-dir="$DIR_BIN"
+}

--- a/bin/src/include/drupal.sh
+++ b/bin/src/include/drupal.sh
@@ -7,12 +7,31 @@
 # Run drush from within the Drupal root ($DIR_WEB folder).
 #
 # Use this if you need to run the drush command from within the actual web root.
-# Do not use it when instaling the make files.
+# Do not use it when installing the make files.
+#
+#
 ##
 function drupal_drush {
-  drush --root="$DIR_WEB" "$@"
+  drupal_drush_run "$@" --root="$DIR_WEB"
 }
 
+##
+# Run drush.
+#
+# This command will run by default the globally installed drush.
+# If the $DRUSH_VERSION is set to a specific version, then it will expect drush
+# to be installed using composer and will run drush from within the
+# bin/vendor/bin directory.
+##
+function drupal_drush_run {
+  local cmd_drush="$DIR_BIN/vendor/bin/drush"
+
+  if [ "$DRUSH_VERSION" == "global" ]; then
+    cmd_drush="drush"
+  fi
+
+  $cmd_drush "$@"
+}
 
 ##
 # Check if there is a working Drupak installation.

--- a/bin/src/init_composer.sh
+++ b/bin/src/init_composer.sh
@@ -18,16 +18,22 @@ function init_composer_run {
   # Hook before install/update composer.
   hook_invoke "init_composer_before"
 
+  # Disable composer x-debug warnings
+  COMPOSER_DISABLE_XDEBUG_WARN=1
+
   if [ -f "$DIR_BIN/composer" ]; then
     init_composer_update
+    echo
+    init_composer_init
+    echo
+    init_composer_update_packages
     echo
   else
     init_composer_install
     echo
+    init_composer_init
+    echo
   fi
-
-  init_composer_init
-  echo
 
   # Hook after install/update composer.
   hook_invoke "init_composer_after"
@@ -47,7 +53,7 @@ function init_composer_install {
 ##
 function init_composer_update {
   markup_h1 "Update composer."
-  $DIR_BIN/composer self-update
+  composer_skeleton_run self-update
 }
 
 ##
@@ -59,8 +65,7 @@ function init_composer_init {
   if [ -f "$DIR_BIN/composer.json" ]; then
     message_success "Composer was already initiated."
   else
-    $DIR_BIN/composer -n init \
-      --working-dir="$DIR_BIN" \
+    composer_skeleton_run -n init \
       --name="drupal-skeleton/bin" \
       --description="PHP packages needed by the skeleton." \
       --author="zero2one <zero2one@serial-graphics.be>" \
@@ -69,4 +74,12 @@ function init_composer_init {
       --type="library"
     message_success "Composer is initiated"
   fi
+}
+
+##
+# Update the composer packages.
+##
+function init_composer_update_packages {
+  markup_h1 "Update installed composer packages"
+  composer_skeleton_run update
 }

--- a/bin/src/init_composer.sh
+++ b/bin/src/init_composer.sh
@@ -20,10 +20,13 @@ function init_composer_run {
 
   if [ -f "$DIR_BIN/composer" ]; then
     init_composer_update
+    echo
   else
     init_composer_install
+    echo
   fi
 
+  init_composer_init
   echo
 
   # Hook after install/update composer.
@@ -45,4 +48,25 @@ function init_composer_install {
 function init_composer_update {
   markup_h1 "Update composer."
   $DIR_BIN/composer self-update
+}
+
+##
+# Initiate the composer environment.
+##
+function init_composer_init {
+  markup_h1 "Initiate composer."
+
+  if [ -f "$DIR_BIN/composer.json" ]; then
+    message_success "Composer was already initiated."
+  else
+    $DIR_BIN/composer -n init \
+      --working-dir="$DIR_BIN" \
+      --name="drupal-skeleton/bin" \
+      --description="PHP packages needed by the skeleton." \
+      --author="zero2one <zero2one@serial-graphics.be>" \
+      --homepage="https://github.com/zero2one/drupal-skeleton" \
+      --license="MIT" \
+      --type="library"
+    message_success "Composer is initiated"
+  fi
 }

--- a/bin/src/init_drush.sh
+++ b/bin/src/init_drush.sh
@@ -1,0 +1,27 @@
+################################################################################
+# Functionality to install or update drush locally.
+################################################################################
+
+
+##
+# Install (download) or (self-)update a local drush instance.
+#
+# This script will trigger 2 "hooks" in the config/<script-name>/ directory:
+# - init_drush_before : Scripts that should run before drush is
+#   installed/updated.
+# - init_drush_after  : Scripts that should run after drush is
+#   installed/updated.
+#
+# The hooks will be called without and with environment suffix.
+##
+function init_drush_run {
+  # Hook before install/update composer.
+  hook_invoke "init_drush_before"
+
+  markup_h1 "Install drush."
+  composer_skeleton_run require drush/drush:dev-master --prefer-source
+  echo
+
+  # Hook after install/update composer.
+  hook_invoke "init_drush_after"
+}

--- a/bin/src/init_drush.sh
+++ b/bin/src/init_drush.sh
@@ -15,11 +15,21 @@
 # The hooks will be called without and with environment suffix.
 ##
 function init_drush_run {
+  # Fallback to dev-master if no configuration found.
+  if [ -z "$DRUSH_VERSION" ]; then
+    DRUSH_VERSION="dev-master"
+  fi
+
   # Hook before install/update composer.
   hook_invoke "init_drush_before"
 
   markup_h1 "Install drush."
-  composer_skeleton_run require drush/drush:dev-master --prefer-source
+  if [ "$DRUSH_VERSION" == "global" ]; then
+    markup_warning "Skip drush installation : globally installed drush will be used."
+  else
+    composer_skeleton_run require drush/drush:$DRUSH_VERSION --prefer-source
+  fi
+
   echo
 
   # Hook after install/update composer.

--- a/config/config_example.sh
+++ b/config/config_example.sh
@@ -26,3 +26,12 @@ DB_HOST="localhost"
 ACCOUNT_NAME="admin"
 ACCOUNT_PASS="drupal"
 ACCOUNT_MAIL="$ACCOUNT_NAME@$SITE_URL"
+
+# The Drush version to use.
+#
+# Use "global" if you want to use the globally installed drush command (outside
+# the skeleton project.
+# Or set the branch or tag name from https://github.com/drush-ops/drush.
+#
+# If the variable is not set, dev-master will be used.
+DRUSH_VERSION="dev-master"


### PR DESCRIPTION
- Add downloading and installing drush locally to the `bin/init` command.
- Add the configuration to define what drush version to use (or use the globally installed drush).
- Updated the `bin/drush` command so it uses the local/global drush as defined in the config file.
