### PR TITLE
#30 Allow using global composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The drupal-skeleton contains a set of bash scripts (commands):
 - [`bin/backup`][link-command-backup] : Create a backup of the installed project.
 - [`bin/restore`][link-command-restore] : Restore the project from one of the
   created backups.
+- [bin/composer](command-composer.md) : A wrapper around a globally installed or
+  local copy of the composer binary.
 - [`bin/drush`][link-command-drush] : Run a drush command within the `web`
   directory.
 

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -8,6 +8,7 @@
 !/README.md
 !/backup
 !/build
+!/composer
 !/drush
 !/init
 !/install

--- a/bin/CHANGELOG.md
+++ b/bin/CHANGELOG.md
@@ -6,6 +6,7 @@
 - #20 : Added bin/init command and its documentation.
 - #23 : Install composer locally by running the bin/init command.
 - #23 : Install drush locally by running the bin/init command.
+- #30 : Add the configuration option to use local or global composer binary.
 
 ### Fixed
 - Error when there is no hook info available for a specific command.

--- a/bin/composer
+++ b/bin/composer
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+################################################################################
+# Script that acts as a wrapper around the composer cli tool.
+#
+# ! Do not change this file !
+# All configuration is in the config directory
+################################################################################
+
+
+composer_params="$@"
+
+# Bootstrap the script.
+source $(dirname $0)/src/bootstrap.sh
+
+# START Script -----------------------------------------------------------------
+markup_debug "Composer params : $composer_params"
+composer_run $composer_params
+markup "${GREY}Finished : $(date '+%Y-%m-%d %H:%M:%S')"
+echo
+
+# END Script -------------------------------------------------------------------
+
+
+exit 0

--- a/bin/docs/README.md
+++ b/bin/docs/README.md
@@ -24,11 +24,12 @@ Overview of all Skeleton Documentation:
   deployed on production.
 - [bin/backup](command-backup.md) : Create a backup of the installed project.
 - [bin/restore](command-restore.md) : Restore one of the backups.
+- [bin/composer](command-composer.md) : A wrapper around a globally installed or
+  local copy of the composer binary.
 - [bin/drush](command-drush.md) : Run a drush command within the `web`
   directory.
 
 Commands installed during the init command:
-- [bin/composer](https://getcomposer.org/) : A local copy of composer.
 - [bin/...](config-bin.md) : Any custom command as defined in the `config/bin`
   directory.
 

--- a/bin/docs/command-composer.md
+++ b/bin/docs/command-composer.md
@@ -1,0 +1,54 @@
+# bin/composer command
+The `bin/composer` command is a wrapper around the
+[composer binary][link-composer]. It allows to use a globally installed composer
+or a locally copy.
+
+What composer binary to use is defined in the `config/config.sh` file using the
+[`$COMPOSER_USE_GLOBAL`][link-config-config-composer] variable.
+
+```bash
+$ bin/composer
+```
+
+
+
+## What does this command do?
+This command has only one task: running composer and pass all arguments as used
+when the `bin/composer` command is called.
+
+
+
+## Command options
+Command options documentation can be viewed in the command line interface by
+running the command with the `-h` or `--help` option.
+
+```bash
+$ bin/composer -h
+```
+
+#### Arguments
+All arguments will be passed to the composer command. Use this as calling
+composer directly. See the [composer documentation][link-composer].
+
+#### Options
+- --help (-h) : Show the command help.
+- --hook-info : Show information about the available hooks.
+- --no-color : Disable all colored output.
+- --confirm (-y) : Skip the confirmation step when the script starts.
+- --verbose (-v) : Verbose, show extra information while running the command.
+
+
+
+## Command hooks
+The `bin/composer` command does not support hooks.
+
+
+
+[Back to overview][link-overview]
+
+
+
+[link-composer]: https://getcomposer.org/
+[link-config-config-composer]: config-config.md#composer
+
+[link-overview]: README.md

--- a/bin/docs/config-config.md
+++ b/bin/docs/config-config.md
@@ -58,6 +58,17 @@ credentials from the config file:
   site url (`$ACCOUNT_NAME@$SITE_URL`).
 
 
+#### Composer
+The skeleton will, by default, download and install composer locally. The
+`COMPOSER_USE_GLOBAL` variable allows to force the skeleton to use the globally
+install composer instead.
+
+- **COMPOSER_USE_GLOBAL=0** : Use the locally installed composer binary.
+- **COMPOSER_USE_GLOBAL=1** : Use the globally installed composer binary.
+
+> Note : The default is to download and install composer locally.
+
+
 #### Drush version
 The skeleton provides the option to use a globally installed drush command or to
 install a local version. This is defined by the `$DRUSH_VERSION` variable.
@@ -95,6 +106,9 @@ DB_HOST="localhost"
 ACCOUNT_NAME="admin"
 ACCOUNT_PASS="drupal"
 ACCOUNT_MAIL="$ACCOUNT_NAME@$SITE_URL"
+
+# Use global composer
+COMPOSER_USE_GLOBAL=1
 
 # Drush version.
 DRUSH_VERSION="dev-master"

--- a/bin/docs/hooks-helpers.md
+++ b/bin/docs/hooks-helpers.md
@@ -235,6 +235,24 @@ message_error "Error demo."
 ![message_error][img-message_error]
 
 
+
+## Composer helpers
+The skeleton provides several Composer helpers:
+
+#### composer_run
+Run the composer binary. This will automatically use the locally or globally
+installed composer. What composer binary will be used depeneds on the
+configuration [`$COMPOSER_USE_GLOBAL`][link-config-config-composer] variable.
+
+#### composer_skeleton_run
+Run a composer command using the `bin/packagist` directory as working directory.
+This directory is used to download and store php packages as needed by the
+skeleton.
+
+> Note this function is a wrapper around the [`composer_run`](#composer_run)
+> function.
+
+
 ## Drupal helpers
 The skeleton provides several Drupal specific helpers:
 
@@ -378,6 +396,7 @@ file_copy_subdirectories "/path/to/source_directory" "/path/to/target_directory"
 
 
 [link-hooks-variables]: hooks-variables.md
+[link-config-config-composer]: config-config.md#composer
 [link-config-config-drush-version]: config-config.md#drush-version
 
 [link-overview]: README.md

--- a/bin/src/drupal_modules_disable.sh
+++ b/bin/src/drupal_modules_disable.sh
@@ -56,7 +56,7 @@ function drupal_modules_disable_run_file {
     return
   fi
 
-  markup_h1 "Disable unwated modules"
+  markup_h1 "Disable unwanted modules"
   source "$drupal_modules_disabe_file"
 
   # Check if there are modules to disable.

--- a/bin/src/help/composer_arguments.txt
+++ b/bin/src/help/composer_arguments.txt
@@ -1,0 +1,2 @@
+  All arguments will be passed to the composer command.
+  Use this as calling composer directly.

--- a/bin/src/help/composer_description.txt
+++ b/bin/src/help/composer_description.txt
@@ -1,0 +1,4 @@
+The composer command is a wrapper around the composer binary. It allows to use
+a globally installed composer or a locally copy.
+What composer binary to use is defined in the config/config.sh file using the
+$COMPOSER_USE_GLOBAL variable.

--- a/bin/src/help/composer_examples.txt
+++ b/bin/src/help/composer_examples.txt
@@ -1,0 +1,2 @@
+  * bin/composer help      Show help about composer.
+  * bin/composer --version Show the composer version.

--- a/bin/src/include/composer.sh
+++ b/bin/src/include/composer.sh
@@ -8,7 +8,13 @@
 # This will run the bin/composer command with surpression of the XDEBUG warning.
 ##
 function composer_run {
-  COMPOSER_DISABLE_XDEBUG_WARN=1 "$DIR_BIN/composer" "$@"
+  local cmd_composer="$DIR_BIN/packagist/composer.phar"
+
+  if [ ! -z "$COMPOSER_USE_GLOBAL" ]; then
+    cmd_composer="composer"
+  fi
+
+  COMPOSER_DISABLE_XDEBUG_WARN=1 "$cmd_composer" "$@"
 }
 
 ##
@@ -18,5 +24,5 @@ function composer_run {
 # installed by the skeleton.
 ##
 function composer_skeleton_run {
-  composer_run "$@" --working-dir="$DIR_BIN"
+  composer_run "$@" --working-dir="$DIR_BIN/packagist"
 }

--- a/bin/src/include/drupal.sh
+++ b/bin/src/include/drupal.sh
@@ -24,7 +24,7 @@ function drupal_drush {
 # bin/vendor/bin directory.
 ##
 function drupal_drush_run {
-  local cmd_drush="$DIR_BIN/vendor/bin/drush"
+  local cmd_drush="$DIR_BIN/packagist/vendor/bin/drush"
 
   if [ "$DRUSH_VERSION" == "global" ]; then
     cmd_drush="drush"

--- a/bin/src/init_composer.sh
+++ b/bin/src/init_composer.sh
@@ -21,7 +21,7 @@ function init_composer_run {
   # Disable composer x-debug warnings
   COMPOSER_DISABLE_XDEBUG_WARN=1
 
-  if [ -f "$DIR_BIN/composer" ]; then
+  if [ -d "$DIR_BIN/composer_src" ]; then
     init_composer_update
     echo
     init_composer_init
@@ -44,8 +44,14 @@ function init_composer_run {
 ##
 function init_composer_install {
   markup_h1 "Install composer."
-  curl -sS https://getcomposer.org/installer \
-    | php -- --install-dir="$DIR_BIN" --filename=composer
+  mkdir -p "$DIR_BIN/packagist"
+
+  if [ -z "$COMPOSER_USE_GLOBAL" ]; then
+    curl -sS https://getcomposer.org/installer \
+      | php -- --install-dir="$DIR_BIN/packagist"
+  else
+    markup_warning "Skip composer installation : globally installed composer will be used."
+  fi
 }
 
 ##
@@ -53,7 +59,12 @@ function init_composer_install {
 ##
 function init_composer_update {
   markup_h1 "Update composer."
-  composer_skeleton_run self-update
+
+  if [ -z "$COMPOSER_USE_GLOBAL" ]; then
+    composer_skeleton_run self-update
+  else
+    markup_warning "Skip composer update : globally installed composer is in use."
+  fi
 }
 
 ##
@@ -62,7 +73,7 @@ function init_composer_update {
 function init_composer_init {
   markup_h1 "Initiate composer."
 
-  if [ -f "$DIR_BIN/composer.json" ]; then
+  if [ -f "$DIR_BIN/packagist/composer.json" ]; then
     message_success "Composer was already initiated."
   else
     composer_skeleton_run -n init \

--- a/config/config_example.sh
+++ b/config/config_example.sh
@@ -34,4 +34,8 @@ ACCOUNT_MAIL="$ACCOUNT_NAME@$SITE_URL"
 # Or set the branch or tag name from https://github.com/drush-ops/drush.
 #
 # If the variable is not set, dev-master will be used.
-DRUSH_VERSION="dev-master"
+#DRUSH_VERSION="global"
+
+# Composer is by default downloaded during the bin/init script.
+# You can optionally use a global installed composer.
+#COMPOSER_USE_GLOBAL=1


### PR DESCRIPTION
- Added configuration variable to the config/config.sh file.
- Moved the composer binary to a subfolder.
- Created a custom bin/composer command that is a wrapper around the local or global composer binary.

See #30 
