### PR TITLE
#32 Support drush.phar

### DIFF
--- a/bin/CHANGELOG.md
+++ b/bin/CHANGELOG.md
@@ -7,6 +7,7 @@
 - #23 : Install composer locally by running the bin/init command.
 - #23 : Install drush locally by running the bin/init command.
 - #30 : Add the configuration option to use local or global composer binary.
+- #32 : Add support to use drush.phar.
 
 ### Fixed
 - Error when there is no hook info available for a specific command.

--- a/bin/composer
+++ b/bin/composer
@@ -13,13 +13,29 @@ composer_params="$@"
 # Bootstrap the script.
 source $(dirname $0)/src/bootstrap.sh
 
+
 # START Script -----------------------------------------------------------------
-markup_debug "Composer params : $composer_params"
+
+markup_debug
+markup_debug "Start : $(date '+%Y-%m-%d %H:%M:%S')"
+markup_debug
+
 composer_run $composer_params
+
+markup_debug
+composer_binary_in_use="local"
+if [ ! -z "$COMPOSER_USE_GLOBAL" ]; then
+  composer_binary_in_use="global"
+fi
+markup_debug "Composer binary used : $composer_binary_in_use"
+markup_debug "Composer params : $composer_params"
+
 markup "${GREY}Finished : $(date '+%Y-%m-%d %H:%M:%S')"
 echo
 
 # END Script -------------------------------------------------------------------
+
+
 
 
 exit 0

--- a/bin/docs/config-config.md
+++ b/bin/docs/config-config.md
@@ -63,7 +63,8 @@ The skeleton will, by default, download and install composer locally. The
 `COMPOSER_USE_GLOBAL` variable allows to force the skeleton to use the globally
 install composer instead.
 
-- **COMPOSER_USE_GLOBAL=0** : Use the locally installed composer binary.
+- **COMPOSER_USE_GLOBAL=0** : Download the composer binary locally and use that
+  to run composer commands.
 - **COMPOSER_USE_GLOBAL=1** : Use the globally installed composer binary.
 
 > Note : The default is to download and install composer locally.
@@ -75,12 +76,12 @@ install a local version. This is defined by the `$DRUSH_VERSION` variable.
 
 The options are:
 
+- **DRUSH_VERSION="phar"** : Download and use drush.phar as drush binary.
 - **DRUSH_VERSION="global"** : Use the globally installed drush command.
 - **DRUSH_VERSION="branch or tag name"** : Download a local drush command, use
-  the branch or tag to determen what version to download.
+  the [branch or tag][link-drush] to determine what version to download.
 
-> Note : The default is to download a local drush using the
-> [dev-master][link-drush-dev-master] branch.
+> Note : The default is to download and use the drush.phar binary.
 
 
 
@@ -121,6 +122,6 @@ DRUSH_VERSION="dev-master"
 
 
 [link-hooks]: hooks.md
-[link-drush-dev-master]: https://github.com/drush-ops/drush/tree/master
+[link-drush]: https://github.com/drush-ops/drush
 
 [link-overview]: README.md

--- a/bin/docs/hooks-variables.md
+++ b/bin/docs/hooks-variables.md
@@ -76,6 +76,17 @@ Is there a working Drupal installation 1/0.
 #### `$CONFIRMED`
 Is the --confirm or -y option passed to the script.
 
+#### `$COMPOSER_USE_GLOBAL`
+Should the globally (1) or locally (0) installed composer binary be used for the
+`bin/composer` command.
+
+[see configuration documentation][link-config-config-composer].
+
+#### `$DRUSH_VERSION`
+What drush version to install and use.
+
+[see configuration documentation][link-config-config-drush-version].
+
 
 
 ## Command argument
@@ -95,6 +106,8 @@ The variables from the command line are accessible using the
 
 
 [link-config-config]: config-config.md
+[link-config-config-composer]: config-config.md#composer
+[link-config-config-drush-version]: config-config.md#drush-version
 [link-hooks-helpers]: hooks-helpers.md
 
 [link-overview]: README.md

--- a/bin/drush
+++ b/bin/drush
@@ -16,8 +16,17 @@ drush_params="$@"
 source $(dirname $0)/src/bootstrap.sh
 
 # START Script -----------------------------------------------------------------
-markup_debug "Drush params : $drush_params"
+
+markup_debug
+markup_debug "Start : $(date '+%Y-%m-%d %H:%M:%S')"
+markup_debug
+
 drupal_drush $drush_params
+
+markup_debug
+markup_debug "Drush binary used : $DRUSH_VERSION"
+markup_debug "Drush params : $drush_params"
+
 markup "${GREY}Finished : $(date '+%Y-%m-%d %H:%M:%S')"
 echo
 

--- a/bin/src/bootstrap.sh
+++ b/bin/src/bootstrap.sh
@@ -63,8 +63,14 @@ DRUPAL_INSTALLED=$( drupal_is_installed )
 if [ $(option_is_set "--confirm") -eq 1 ] || [ $(option_is_set "-y") -eq 1 ]; then
   CONFIRMED=1
 else
- CONFIRMED=0
+  CONFIRMED=0
 fi
+
+# Set the default variable value(s) for composer.
+composer_variable_use_global
+
+# Set the default variable value(s) for drush.
+drupal_drush_variable_version
 
 # Load Help.
 source "$DIR_SRC/include/help.sh"

--- a/bin/src/include/composer.sh
+++ b/bin/src/include/composer.sh
@@ -26,3 +26,12 @@ function composer_run {
 function composer_skeleton_run {
   composer_run "$@" --working-dir="$DIR_BIN/packagist"
 }
+
+##
+# Make sure that a COMPOSER_USE_GLOBAL variable is set.
+##
+function composer_variable_use_global {
+  if [ ! -z "$COMPOSER_USE_GLOBAL" ]; then
+    COMPOSER_USE_GLOBAL=0
+  fi
+}

--- a/bin/src/include/drupal.sh
+++ b/bin/src/include/drupal.sh
@@ -24,10 +24,14 @@ function drupal_drush {
 # bin/vendor/bin directory.
 ##
 function drupal_drush_run {
-  local cmd_drush="$DIR_BIN/packagist/vendor/bin/drush"
+  local cmd_drush=""
 
-  if [ "$DRUSH_VERSION" == "global" ]; then
+  if [ -z "$DRUSH_VERSION" ] || [ "$DRUSH_VERSION" == "phar" ]; then
+    cmd_drush="$DIR_BIN/packagist/drush.phar"
+  elif [ "$DRUSH_VERSION" == "global" ]; then
     cmd_drush="drush"
+  else
+    cmd_drush="$DIR_BIN/packagist/vendor/bin/drush"
   fi
 
   $cmd_drush "$@"

--- a/bin/src/include/drupal.sh
+++ b/bin/src/include/drupal.sh
@@ -26,7 +26,7 @@ function drupal_drush {
 function drupal_drush_run {
   local cmd_drush=""
 
-  if [ -z "$DRUSH_VERSION" ] || [ "$DRUSH_VERSION" == "phar" ]; then
+  if [ "$DRUSH_VERSION" == "phar" ]; then
     cmd_drush="$DIR_BIN/packagist/drush.phar"
   elif [ "$DRUSH_VERSION" == "global" ]; then
     cmd_drush="drush"
@@ -35,6 +35,15 @@ function drupal_drush_run {
   fi
 
   $cmd_drush "$@"
+}
+
+##
+# Make sure that the DRUSH_VERSION variable is set.
+##
+function drupal_drush_variable_version {
+  if [ -z "$DRUSH_VERSION" ]; then
+    DRUSH_VERSION="phar"
+  fi
 }
 
 ##

--- a/bin/src/init_composer.sh
+++ b/bin/src/init_composer.sh
@@ -18,9 +18,6 @@ function init_composer_run {
   # Hook before install/update composer.
   hook_invoke "init_composer_before"
 
-  # Disable composer x-debug warnings
-  COMPOSER_DISABLE_XDEBUG_WARN=1
-
   if [ -d "$DIR_BIN/composer_src" ]; then
     init_composer_update
     echo

--- a/bin/src/init_drush.sh
+++ b/bin/src/init_drush.sh
@@ -15,11 +15,6 @@
 # The hooks will be called without and with environment suffix.
 ##
 function init_drush_run {
-  # Fallback to dev-master if no configuration found.
-  if [ -z "$DRUSH_VERSION" ]; then
-    DRUSH_VERSION="phar"
-  fi
-
   # Hook before install/update composer.
   hook_invoke "init_drush_before"
 

--- a/bin/src/init_drush.sh
+++ b/bin/src/init_drush.sh
@@ -17,7 +17,7 @@
 function init_drush_run {
   # Fallback to dev-master if no configuration found.
   if [ -z "$DRUSH_VERSION" ]; then
-    DRUSH_VERSION="dev-master"
+    DRUSH_VERSION="phar"
   fi
 
   # Hook before install/update composer.
@@ -26,6 +26,10 @@ function init_drush_run {
   markup_h1 "Install drush."
   if [ "$DRUSH_VERSION" == "global" ]; then
     markup_warning "Skip drush installation : globally installed drush will be used."
+  elif [ "$DRUSH_VERSION" == "phar" ]; then
+    curl -o "$DIR_BIN/packagist/drush.phar" http://files.drush.org/drush.phar
+    chmod +x "$DIR_BIN/packagist/drush.phar"
+    message_success "Drush downloaded to $DIR_BIN/packagist/drush.phar"
   else
     composer_skeleton_run require drush/drush:$DRUSH_VERSION --prefer-source
   fi

--- a/config/config_example.sh
+++ b/config/config_example.sh
@@ -27,15 +27,19 @@ ACCOUNT_NAME="admin"
 ACCOUNT_PASS="drupal"
 ACCOUNT_MAIL="$ACCOUNT_NAME@$SITE_URL"
 
-# The Drush version to use.
-#
-# Use "global" if you want to use the globally installed drush command (outside
-# the skeleton project.
-# Or set the branch or tag name from https://github.com/drush-ops/drush.
-#
-# If the variable is not set, dev-master will be used.
-#DRUSH_VERSION="global"
-
 # Composer is by default downloaded during the bin/init script.
 # You can optionally use a global installed composer.
 #COMPOSER_USE_GLOBAL=1
+
+# The Drush version to use.
+#
+# Options:
+# - phar : use the drush.phar file as the local drush binary. This is the
+#   default option.
+# - branch or tag name : use a specific version by setting the variable to the
+#   proper branch or tag name (eg. dev-master).
+#   See https://github.com/drush-ops/drush.
+# - global : use the globally installed drush command (outside the skeleton).
+#
+# If the variable is not set, phar will be used.
+#DRUSH_VERSION="global"

--- a/config/install/drupal_modules_enable_after_dev.sh
+++ b/config/install/drupal_modules_enable_after_dev.sh
@@ -16,5 +16,5 @@ echo
 
 # Enable the theme debugging.
 markup_h1 "Enable theme debugging"
-drush vset theme_debug 1
+drupal_drush vset theme_debug 1
 echo


### PR DESCRIPTION
Support phar in the configuration.
Install it based on the configuration (phar is now the default option).
Use it in bin/drush based on the configuration.
