### PR TITLE
#35 bin init only download if needed

### DIFF
--- a/bin/docs/command-init.md
+++ b/bin/docs/command-init.md
@@ -76,6 +76,9 @@ $ bin/init -h
 There are no arguments for this command.
 
 #### Options
+- --force (-f) : The init script will only download dependencies if they are not
+  yet downloaded. The force option will delete the files and download them
+  again.
 - --env=\<name\> : The environment to run the script for (default : dev).
 - --help (-h) : Show the command help.
 - --hook-info : Show information about the available hooks.

--- a/bin/src/help/init_options.txt
+++ b/bin/src/help/init_options.txt
@@ -1,0 +1,3 @@
+  --force (-f)          The init script will only download dependencies if they
+                        are not yet downloaded. The force option will delete the
+                        files and download them again.

--- a/bin/src/init_composer.sh
+++ b/bin/src/init_composer.sh
@@ -18,7 +18,9 @@ function init_composer_run {
   # Hook before install/update composer.
   hook_invoke "init_composer_before"
 
-  if [ -d "$DIR_BIN/composer_src" ]; then
+  init_composer_with_force
+
+  if [ -d "$DIR_BIN/packagist" ]; then
     init_composer_update
     echo
     init_composer_init
@@ -34,6 +36,30 @@ function init_composer_run {
 
   # Hook after install/update composer.
   hook_invoke "init_composer_after"
+}
+
+##
+# Check if the init command was called with force.
+#
+# This will delete downloaded files so the init command will be run as a new
+# install.
+##
+function init_composer_with_force {
+  if [ $(option_is_set "-f") -ne 1 ] && [ $(option_is_set "--force") -ne 1 ]; then
+    markup_debug "Init with force : No force used on the skeleton."
+    markup_debug
+    return
+  fi
+
+  if [ ! -d "$DIR_BIN/packagist" ]; then
+    markup_debug "Init with force : No bin/packagist directory to delete."
+    markup_debug
+    return
+  fi
+
+  rm -Rf "$DIR_BIN/packagist"
+  message_success "Init with force : bin/packagist directory is deleted."
+  echo
 }
 
 ##

--- a/bin/src/init_drush.sh
+++ b/bin/src/init_drush.sh
@@ -21,10 +21,18 @@ function init_drush_run {
   markup_h1 "Install drush."
   if [ "$DRUSH_VERSION" == "global" ]; then
     markup_warning "Skip drush installation : globally installed drush will be used."
+
   elif [ "$DRUSH_VERSION" == "phar" ]; then
-    curl -o "$DIR_BIN/packagist/drush.phar" http://files.drush.org/drush.phar
-    chmod +x "$DIR_BIN/packagist/drush.phar"
-    message_success "Drush downloaded to $DIR_BIN/packagist/drush.phar"
+    init_drush_phar_with_force
+
+    if [ ! -f "$DIR_BIN/packagist/drush.phar" ]; then
+      curl -o "$DIR_BIN/packagist/drush.phar" http://files.drush.org/drush.phar
+      chmod +x "$DIR_BIN/packagist/drush.phar"
+      message_success "Drush downloaded to bin/packagist/drush.phar"
+    else
+      message_success "Drush was already downloaded to bin/packagist/drush.phar"
+    fi
+
   else
     composer_skeleton_run require drush/drush:$DRUSH_VERSION --prefer-source
   fi
@@ -33,4 +41,28 @@ function init_drush_run {
 
   # Hook after install/update composer.
   hook_invoke "init_drush_after"
+}
+
+##
+# Check if the init command was called with force.
+#
+# This will delete downloaded files so the init command will be run as a new
+# install.
+##
+function init_drush_phar_with_force {
+  if [ $(option_is_set "-f") -ne 1 ] && [ $(option_is_set "--force") -ne 1 ]; then
+    markup_debug "Init with force : No force used on the skeleton."
+    markup_debug
+    return
+  fi
+
+  if [ ! -f "$DIR_BIN/packagist/drush.phar" ]; then
+    markup_debug "Init with force : No drush.phar file to delete."
+    markup_debug
+    return
+  fi
+
+  rm -f "$DIR_BIN/packagist/drush.phar"
+  message_success "Init with force : drush.phar file is deleted."
+  echo
 }


### PR DESCRIPTION
Added a --force (-f) option to the bin/init command:
- Force downloading all dependencies.
- Only download drush.phar if not already on disc.
