### PR TITLE
"See the custom commands documentation" linked to 404 page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,5 +227,5 @@ See [hooks documentation][link-hooks].
 [link-command-drush]: docs/command-drush.md
 [link-command-coder]: docs/command-coder.md
 [link-hooks]: docs/hooks.md
-[link-config-bin]: config-bin.sh
+[link-config-bin]: docs/config-bin.md
 [link-quick-start]: docs/quick-start.md


### PR DESCRIPTION
"See the custom commands documentation" linked to 404 page. Updated the link to the proper page.
